### PR TITLE
chore: Image tags based on the github event

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -17,11 +17,8 @@ permissions:
   packages: write
 
 jobs:
-  prepare:
+  publish-docker-image:
     runs-on: ubuntu-latest
-    outputs:
-      is-head-main: ${{ steps.is-head-main.outcome == 'success' }}
-      is-latest-release: ${{ steps.is-latest-release.outcome == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,22 +29,6 @@ jobs:
         run: git rev-parse HEAD | grep -x ${{ github.sha }}
         shell: bash
 
-      - name: Check whether the release is latest
-        continue-on-error: true
-        id: is-latest-release
-        if: github.event_name == 'release'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release view --json tagName --jq .tagName | grep -x ${{ github.event.release.tag_name }}
-        shell: bash
-
-  publish-docker-image:
-    runs-on: ubuntu-latest
-    needs: prepare
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -55,8 +36,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
-            type=edge,enable=${{ needs.prepare.outputs.is-head-main == 'true' }}
-            type=raw,value=latest,enable=${{ needs.prepare.outputs.is-latest-release == 'true' }}
+            type=edge,enable=${{ steps.is-head-main.outcome == 'success' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -17,8 +17,33 @@ permissions:
   packages: write
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      is-head-main: ${{ steps.is-head-main.outcome == 'success' }}
+      is-latest-release: ${{ steps.is-latest-release.outcome == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check whether this event is the HEAD of main
+        continue-on-error: true
+        id: is-head-main
+        run: git rev-parse HEAD | grep -x ${{ github.sha }}
+        shell: bash
+
+      - name: Check whether the release is latest
+        continue-on-error: true
+        id: is-latest-release
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release view --json tagName --jq .tagName | grep -x ${{ github.event.release.tag_name }}
+        shell: bash
+
   publish-docker-image:
     runs-on: ubuntu-latest
+    needs: prepare
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,8 +54,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
-            type=raw,value=edge
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=edge,enable=${{ needs.prepare.outputs.is-head-main == 'true' }}
+            type=raw,value=latest,enable=${{ needs.prepare.outputs.is-latest-release == 'true' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=edge,enable=${{ needs.prepare.outputs.is-head-main == 'true' }}
             type=raw,value=latest,enable=${{ needs.prepare.outputs.is-latest-release == 'true' }}
 


### PR DESCRIPTION
This PR will introduce versioned tags for the image. This will enable us to pin the application to a specific version.

The image tagged with edge is built every time a change is pushed to the main branch. The images tagged with a version (and latest) are built when [a GitHub release is created](https://github.com/privacybydesign/irmatube/releases/new) and will take on the version that is given for that release.

An example repository can be found here: https://github.com/jappe999/image-release-strategy