### PR TITLE
chore(fix): Write security events

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: write
   packages: write
+  security-events: write
 
 jobs:
   publish-docker-image:


### PR DESCRIPTION
Forgot give permission to the action to write security events. Still strange that it didn't throw an error in #16.