### PR TITLE
chore: Tag image with branch name when manually dispatched

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -11,6 +11,7 @@ on:
   schedule:
     # Run every monday on 9:00 in the morning (UTC).
     - cron: '0 9 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -38,6 +39,7 @@ jobs:
           tags: |
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=edge,enable=${{ steps.is-head-main.outcome == 'success' }}
+            type=ref,event=branch,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This can come in handy when testing specific features. Change is already in use in https://github.com/privacybydesign/irma-saml-bridge/pull/14/.